### PR TITLE
sed_log(): crop $text from end to prevent fatal SQL error on database insert; sed_javascript() allow code to work

### DIFF
--- a/system/functions.php
+++ b/system/functions.php
@@ -3204,8 +3204,15 @@ function sed_load_forum_structure()
 function sed_log($text, $group = 'def')
 	{
 	global $db_logger, $sys, $usr, $_SERVER;
+        $log_text_errormsg = sed_sql_prep($text);
+        $log_text_request = sed_sql_prep(' - '.$_SERVER['REQUEST_URI']);
+        $log_text = $log_text_errormsg . $log_text_request;
+        if (strlen($log_text) > 255) {
+            $log_text_errormsg = substr($log_text_errormsg,0,255 - strlen($log_text_request));
+            $log_text = $log_text_errormsg . $log_text_request;
+        }
 
-	$sql = sed_sql_query("INSERT INTO $db_logger (log_date, log_ip, log_name, log_group, log_text) VALUES (".(int)$sys['now_offset'].", '".$usr['ip']."', '".sed_sql_prep($usr['name'])."', '$group', '".sed_sql_prep($text.' - '.$_SERVER['REQUEST_URI'])."')");
+        $sql = sed_sql_query("INSERT INTO $db_logger (log_date, log_ip, log_name, log_group, log_text) VALUES (".(int)$sys['now_offset'].", '".$usr['ip']."', '".sed_sql_prep($usr['name'])."', '$group', '$log_text')");
 	return;
 	}
 

--- a/system/functions.php
+++ b/system/functions.php
@@ -3068,7 +3068,7 @@ function sed_is_bot()
 function sed_javascript($more='')
 	{
 	$result = "<script type=\"text/javascript\" src=\"system/javascript/core.js\"></script>\n";
-	$result .= (!empty($more)) ? "<script type=\"text/javascript\"> <!-- ".$more." //-->  </script>" : '';
+        $result .= (!empty($more)) ? $more : '';
 	return ($result);
 	}
 


### PR DESCRIPTION
sed_log() proposed change: With very verbose error message ($text), my app crashed with "Fatal error: SQL error: Data too long for column 'log_text' at row..." . This modification fixes that for good by cropping $text from end considering also the length of the URI to be inserted. 
sed_javascript() proposed change: To allow extra code with $more to be effective on page, one can not wrap it with comment tags. Had to fix this to deal with Google reCAPTCHA.
